### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/Kafka/docker-compose.yml
+++ b/Kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   kafka:
     container_name: kafka
-    image: bitnami/kafka:3.9.0
+    image: soldevelo/kafka:3.9.0
     environment:
       # Node ID and Roles
       KAFKA_KRAFT_CLUSTER_ID: my-cluster-id


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/kafka:3.9.0` → [`soldevelo/kafka:3.9.0`](https://hub.docker.com/r/soldevelo/kafka)